### PR TITLE
Fix API endpoint for disabling users

### DIFF
--- a/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
+++ b/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
@@ -92,14 +92,12 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
   end
 
-  def destroy do
+  def destroy
     @api_user = ApiUser.find(params[:id])
+    authorize(@api_user)
     @api_user.enabled = false
-    if(@api_user.save)
-      head :no_content
-    else
-      format.json { render(:json => errors_response(@api_user), :status => :unprocessable_entity) }
-    end
+    @api_user.save
+    respond_with(:api_v1, @api_user, :root => "api_user")
   end
 
   private

--- a/src/api-umbrella/web-app/app/policies/api_user_policy.rb
+++ b/src/api-umbrella/web-app/app/policies/api_user_policy.rb
@@ -52,4 +52,9 @@ class ApiUserPolicy < ApplicationPolicy
       update?
     end
   end
+
+  def destroy?
+    update?
+  end
+
 end


### PR DESCRIPTION
Implementation done in commit e396ad323cb0da45d873bcd940059b8e7c904905 is not working correctly. This PR fixes ruby syntax and other aspects of the destroy method implementation.