### PR TITLE
IDM Authorization, authentication and trusted applications 

### DIFF
--- a/src/api-umbrella/proxy/middleware/api_key_validator.lua
+++ b/src/api-umbrella/proxy/middleware/api_key_validator.lua
@@ -52,7 +52,8 @@ return function(settings)
   -- Find if and IdP was set
   if settings and settings["ext_auth_allowed"] and config["gatekeeper"]["default_idp"] then
     api_key.idp=config["gatekeeper"]["default_idp"]
-    api_key.idp.app_id = settings["idp_app_id"]
+    api_key.app_id = settings["idp_app_id"]
+    api_key.mode = settings["idp_mode"]
   end
 
   if is_empty(api_key["key_value"]) then

--- a/src/api-umbrella/proxy/middleware/api_key_validator.lua
+++ b/src/api-umbrella/proxy/middleware/api_key_validator.lua
@@ -53,7 +53,10 @@ return function(settings)
   if settings and settings["ext_auth_allowed"] and config["gatekeeper"]["default_idp"] then
     api_key.idp=config["gatekeeper"]["default_idp"]
     api_key.app_id = settings["idp_app_id"]
-    api_key.mode = settings["idp_mode"]
+    api_key.mode = "authentication"
+    if settings["idp_mode"] then
+      api_key.mode = settings["idp_mode"]
+    end
   end
 
   if is_empty(api_key["key_value"]) then

--- a/src/api-umbrella/utils/idp.lua
+++ b/src/api-umbrella/utils/idp.lua
@@ -11,7 +11,9 @@ local _M = {}
 function _M.first(dict)
     local idp_back_name = dict["idp"]["backend_name"]
     local token = dict["key_value"]
-    local idp_host, result, res, err, rpath
+    local idp_host, result, res, err, rpath,resource, method
+    local app_id = dict["app_id"]
+    local mode = dict["mode"]
     local ssl=false
     local httpc = http.new()
     httpc:set_timeout(45000)
@@ -23,9 +25,16 @@ function _M.first(dict)
     if idp_back_name == "google-oauth2" then
         rpath = "/oauth2/v3/userinfo"
         idp_host="https://www.googleapis.com"
-    elseif idp_back_name == "fiware-oauth2" then
+    elseif idp_back_name == "fiware-oauth2" and mode == "authorization" then
         rpath = "/user"
         idp_host = dict["idp"]["host"]
+        resource = ngx.ctx.uri
+        method = ngx.ctx.request_method
+        rquery = "access_token="..token.."&app_id="..app_id.."&resource="..resource.."&action="..method
+    elseif idp_back_name == "fiware-oauth2" and mode == "authentication" then
+        rpath = "/user"
+        idp_host = dict["idp"]["host"]
+        rquery = "access_token="..token.."&app_id="..app_id
     elseif idp_back_name == "facebook-oauth2" then
         rpath = "/me"
         idp_host="https://graph.facebook.com"
@@ -48,10 +57,6 @@ function _M.first(dict)
         end
         result = cjson.decode(body)
 
-        -- Validate the app id (token scope) for FIWARE services
-        if idp_back_name == "fiware-oauth2" and dict["idp"]["app_id"] ~= result["app_id"] then
-            return nil, "The provided token is not valid for the current scope"
-        end
     end
 
     return result, err


### PR DESCRIPTION
Hi Apinf Team,

I am Andrés Muñoz from Fiware UPM team. In this pull request, I am adding features for Authentication and authorization using FIWARE IDM. It includes new params in the requests. The mode of use (authentication or authorization) must be included in the creation of the API Backend. Fully compatible with the FIWARE IDM 7.4. From this release, the trusted application's validation will be managed directly by the IDM, so you only need to include your app _id in your request and the IDM will validate if that app_id is in the trusted applications stored in the IDM. For Authorization is needed to add the action(GET or POST), the resource (/resource/things/) and the app_id.